### PR TITLE
add 19 read-only tools and containerize

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,4 @@
+.env
+.venv
+__pycache__
+*.pyc 

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code (uses .containerignore)
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Entrypoint
+CMD ["python", "server.py"] 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
-.venv:
-	python -m venv .venv
+.PHONY: build run clean test
 
-.PHONY: setup
-setup: .venv
-	.venv/bin/pip install -r requirements.txt
+# Build the Podman image
+build:
+	podman build -t jira-mcp:latest .
+
+# Run the container
+run:
+	podman run --rm -p 8000:8000 -e JIRA_URL=https://issues.redhat.com -e JIRA_API_TOKEN=$$JIRA_API_TOKEN jira-mcp:latest
+
+# Clean up Podman images
+clean:
+	podman rmi jira-mcp:latest || true
+
+# Test the server
+test:
+	podman run --rm -i -e JIRA_URL=https://issues.redhat.com -e JIRA_API_TOKEN=$$JIRA_API_TOKEN jira-mcp:latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redhat-ai-tools/jira-mcp
 
-For use with Cursor to provide access to Jira.
+A containerized MCP server for Cursor to provide access to Jira.
 
 > [!IMPORTANT]
 > This project is experimental and was initially created as a learning exercise.
@@ -12,42 +12,35 @@ For use with Cursor to provide access to Jira.
 
 Example configuration file for Cursor, probably in `~/.cursor/mcp.json`:
 
-```json
-{
-  "mcpServers": {
-    "jira-mcp": {
-      "command": "/some/path/jira-mcp/server.sh",
-      "description": "A simple MCP server to query Jira issues"
-    }
-  }
-}
-```
+## Prerequisites
 
-## Getting started
+- **Podman** - Install with `sudo dnf install podman` (Fedora/RHEL) or `brew install podman` (macOS)
+- **Make** - Usually pre-installed on most systems
 
-* Run `make setup` to set up a python venv environment and install
-  the dependencies.
-* (Optional) Run `source .venv/bin/activate` to set the venv python
-  path in your terminal.
-* Go to your Jira profile page and create a personal access token, for
-  example [here][rh-token-page].
-* Copy `.env.example` to `.env`, add your token to that file, and update
-  the url as required.
-* Go to "Tools & Integrations" in the Cursor settings and paste in the JSON
-  from above. Adjust the command path as required.
-* If it's working you should see a green indicator and "1 tools enabled".
-* You should then be able to refer to Jiras in the Cursor AI pane, e.g.
-  "summarize the requirements for jira EC-1332".
 
-[rh-token-page]: https://issues.redhat.com/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens
+## Quick Start
 
-## Notes
+1. **Build the Podman Image:**
+   ```bash
+   make build
+   ```
+2. **Get Your Jira API Token:**
+   Go to [Red Hat Jira Personal Access Tokens](https://issues.redhat.com/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens) and create a new token.
+3. **Configure Cursor:**
+   Add this to your `~/.cursor/mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "jira-mcp": {
+         "command": "podman",
+         "args": ["run", "--rm", "-i", "-e", "JIRA_URL=https://issues.redhat.com", "-e", "JIRA_API_TOKEN=${JIRA_API_TOKEN}", "jira-mcp:latest"],
+         "description": "A containerized MCP server to query Jira issues"
+       }
+     }
+   }
+   ```
 
-* The instructions above assume you want to use
-  [venv](https://docs.python.org/3/library/venv.html).
-  You can use system python if you prefer.
-  Do a `pip install -r requirements.txt` and adjust
-  `server.sh` as required.
+> **Note:** You do not need to manually run the container. Cursor will automatically start the MCP server when needed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,57 @@ Example configuration file for Cursor, probably in `~/.cursor/mcp.json`:
 
 > **Note:** You do not need to manually run the container. Cursor will automatically start the MCP server when needed.
 
+## Available Tools
+
+This MCP server provides the following tools:
+
+### Issue Search
+- `get_jira` - Get details for a specific Jira issue by key.
+- `search_issues` - Search issues using JQL
+
+### Project Management
+- `list_projects` - List all projects
+- `get_project` - Get project details by key
+- `get_project_components` - Get components for a project
+- `get_project_versions` - Get versions for a project
+- `get_project_roles` - Get roles for a project
+- `get_project_permission_scheme` - Get permission scheme for a project
+- `get_project_issue_types` - Get issue types for a project
+
+### Board & Sprint Management
+- `list_boards` - List all boards
+- `get_board` - Get board details by ID
+- `list_sprints` - List sprints for a board
+- `get_sprint` - Get sprint details by ID
+- `get_issues_for_board` - Get issues for a board
+- `get_issues_for_sprint` - Get issues for a sprint
+
+### User Management
+- `search_users` - Search users by query
+- `get_user` - Get user details by account ID
+- `get_current_user` - Get current user info
+- `get_assignable_users_for_project` - Get assignable users for a project
+- `get_assignable_users_for_issue` - Get assignable users for an issue
+
+## Development Commands
+
+- `make build` - Build the Podman image
+- `make run` - Run the container (requires JIRA_API_TOKEN env var)
+- `make test` - Test the server
+- `make clean` - Clean up Podman images
+
+## Troubleshooting
+
+### Server Not Starting
+- Ensure Podman is running
+- Check that the JIRA_API_TOKEN is correct
+- Verify the Podman image was built successfully with `podman images | grep jira-mcp`
+
+### Connection Issues
+- Restart Cursor after configuration changes
+- Check Cursor's developer console for error messages
+- Verify the Jira URL is accessible from your network
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from jira import JIRA
 from fastmcp import FastMCP
 from fastapi import HTTPException
+import json
 
 # ─── 1. Load environment variables ─────────────────────────────────────────────
 load_dotenv()
@@ -13,7 +14,7 @@ JIRA_URL       = os.getenv("JIRA_URL")
 JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN")
 
 if not all([JIRA_URL, JIRA_API_TOKEN]):
-    raise RuntimeError("Missing JIRA_URL or JIRA_API_TOKEN in .env")
+    raise RuntimeError("Missing JIRA_URL or JIRA_API_TOKEN environment variables")
 
 # ─── 2. Create a Jira client ───────────────────────────────────────────────────
 #    Uses token_auth (API token) for authentication.
@@ -41,6 +42,187 @@ def get_jira(issue_key: str) -> str:
     description = issue.fields.description or ""
 
     return f"# {issue_key}: {summary}\n\n{description}"
+
+def to_markdown(obj):
+    if isinstance(obj, dict):
+        return '```json\n' + json.dumps(obj, indent=2) + '\n```'
+    elif hasattr(obj, 'raw'):
+        return '```json\n' + json.dumps(obj.raw, indent=2) + '\n```'
+    elif isinstance(obj, list):
+        return '\n'.join([to_markdown(o) for o in obj])
+    else:
+        return str(obj)
+
+@mcp.tool()
+def search_issues(jql: str, max_results: int = 10) -> str:
+    """Search issues using JQL."""
+    try:
+        issues = jira_client.search_issues(jql, maxResults=max_results)
+        return to_markdown([i.raw for i in issues])
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"JQL search failed: {e}")
+
+@mcp.tool()
+def search_users(query: str, max_results: int = 10) -> str:
+    """Search users by query."""
+    try:
+        users = jira_client.search_users(query, maxResults=max_results)
+        return to_markdown([u.raw for u in users])
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to search users: {e}")
+
+@mcp.tool()
+def list_projects() -> str:
+    """List all projects."""
+    try:
+        projects = jira_client.projects()
+        return to_markdown([p.raw for p in projects])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch projects: {e}")
+
+@mcp.tool()
+def get_project(project_key: str) -> str:
+    """Get a project by key."""
+    try:
+        project = jira_client.project(project_key)
+        return to_markdown(project)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch project: {e}")
+
+@mcp.tool()
+def get_project_components(project_key: str) -> str:
+    """Get components for a project."""
+    try:
+        components = jira_client.project_components(project_key)
+        return to_markdown([c.raw for c in components])
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch components: {e}")
+
+@mcp.tool()
+def get_project_versions(project_key: str) -> str:
+    """Get versions for a project."""
+    try:
+        versions = jira_client.project_versions(project_key)
+        return to_markdown([v.raw for v in versions])
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch versions: {e}")
+
+@mcp.tool()
+def get_project_roles(project_key: str) -> str:
+    """Get roles for a project."""
+    try:
+        roles = jira_client.project_roles(project_key)
+        return to_markdown(roles)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch roles: {e}")
+
+@mcp.tool()
+def get_project_permission_scheme(project_key: str) -> str:
+    """Get permission scheme for a project."""
+    try:
+        scheme = jira_client.project_permissionscheme(project_key)
+        return to_markdown(scheme.raw)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch permission scheme: {e}")
+
+@mcp.tool()
+def get_project_issue_types(project_key: str) -> str:
+    """Get issue types for a project."""
+    try:
+        types = jira_client.project_issue_types(project_key)
+        return to_markdown([t.raw for t in types])
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch issue types: {e}")
+
+@mcp.tool()
+def get_current_user() -> str:
+    """Get current user info."""
+    try:
+        user = jira_client.myself()
+        return to_markdown(user)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch current user: {e}")
+
+@mcp.tool()
+def get_user(account_id: str) -> str:
+    """Get user by account ID."""
+    try:
+        user = jira_client.user(account_id)
+        return to_markdown(user.raw)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch user: {e}")
+
+@mcp.tool()
+def get_assignable_users_for_project(project_key: str, query: str = "", max_results: int = 10) -> str:
+    """Get assignable users for a project."""
+    try:
+        users = jira_client.search_assignable_users_for_projects(query, project_key, maxResults=max_results)
+        return to_markdown([u.raw for u in users])
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to get assignable users: {e}")
+
+@mcp.tool()
+def get_assignable_users_for_issue(issue_key: str, query: str = "", max_results: int = 10) -> str:
+    """Get assignable users for an issue."""
+    try:
+        users = jira_client.search_assignable_users_for_issues(query, issueKey=issue_key, maxResults=max_results)
+        return to_markdown([u.raw for u in users])
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to get assignable users: {e}")
+
+@mcp.tool()
+def list_boards(max_results: int = 10) -> str:
+    """List boards."""
+    try:
+        boards = jira_client.boards(maxResults=max_results)
+        return to_markdown([b.raw for b in boards])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch boards: {e}")
+
+@mcp.tool()
+def get_board(board_id: int) -> str:
+    """Get board by ID."""
+    try:
+        board = jira_client.board(board_id)
+        return to_markdown(board.raw)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch board: {e}")
+
+@mcp.tool()
+def list_sprints(board_id: int, max_results: int = 10) -> str:
+    """List sprints for a board."""
+    try:
+        sprints = jira_client.sprints(board_id, maxResults=max_results)
+        return to_markdown([s.raw for s in sprints])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch sprints: {e}")
+
+@mcp.tool()
+def get_sprint(sprint_id: int) -> str:
+    """Get sprint by ID."""
+    try:
+        sprint = jira_client.sprint(sprint_id)
+        return to_markdown(sprint.raw)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Failed to fetch sprint: {e}")
+
+@mcp.tool()
+def get_issues_for_board(board_id: int, max_results: int = 10) -> str:
+    """Get issues for a board."""
+    try:
+        issues = jira_client.get_issues_for_board(board_id, maxResults=max_results)
+        return to_markdown([i.raw for i in issues])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch issues for board: {e}")
+
+@mcp.tool()
+def get_issues_for_sprint(board_id: int, sprint_id: int, max_results: int = 10) -> str:
+    """Get issues for a sprint in a board."""
+    try:
+        issues = jira_client.get_all_issues_for_sprint_in_board(board_id, sprint_id, maxResults=max_results)
+        return to_markdown([i.raw for i in issues])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch issues for sprint: {e}")
 
 # ─── 5. Run the HTTP-based MCP server on port 8000 ───────────────────────────────
 if __name__ == "__main__":

--- a/server.sh
+++ b/server.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-THIS_DIR=$(dirname "$0")
-PYTHON=$THIS_DIR/.venv/bin/python
-$PYTHON $THIS_DIR/server.py


### PR DESCRIPTION
Resolves issue #4 
### Summary

This PR migrates the Jira MCP server to a fully containerized workflow using **Podman** and adds 19 Jira tools for read only issue, project, board, sprint, and user operations.

---

### Key Changes

- **Containerization:**  
  - Added a `Dockerfile` and updated scripts for Podman-based development and deployment.
  - Removed legacy virtual environment and non-containerized setup instructions.
  - Updated `Makefile` for streamlined container commands.

- **Documentation:**  
  - Refreshed `README.md` to focus on the container-first workflow.
  - Added clear setup, usage, and troubleshooting instructions.
  - Listed all available tools with descriptions.

---

Thoughts on the changes to containerize. I followed a similar pattern to https://github.com/redhat-ai-tools/sealights-mcp, this allowed their maintainer to pretty easily take this one step further and host the server on a deployment in OpenShift. We can discuss this change, I could always just add the tools if we like the venv approach for now.

![jira-mcp-tools](https://github.com/user-attachments/assets/31a6b648-cd94-4e1c-918f-9995be3fd7c0)


Assisted-by: Cursor AI